### PR TITLE
feat: Create Terraform foundation for remote state backend

### DIFF
--- a/terraform/foundation/.terraform.lock.hcl
+++ b/terraform/foundation/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.14.1"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:vs0TwpXyy//7ORn5+2P+LA9oQJR1cnwSVhEjG2hWFiM=",
+    "zh:14d0b4b3dffb3368e6257136bbab1f93d419863dd65d99ef80ca2c1dd3c72a1e",
+    "zh:1de3601251f87a0a989c4b3474baa2efcaf491804f8d7afe15421b728bac5dc5",
+    "zh:2cfe42b853a3b4117bdbb73e5715035eac9b8d753d6e653fd5f30a807a36b985",
+    "zh:3dd8a0336face356928faf2396065634739ef2c3ac3dcaa655570df205559fd9",
+    "zh:42712baca386b84e089b1db8b7844038557f4039b32d8702611aa67eadef7d0f",
+    "zh:4ffc698099e4d7ffc6b0490a4e78ad66b041afd54e988b8bf8e229bcdd4b3ead",
+    "zh:52a6a3b01cb34394b0d06b273b27702fb9d795290a02e5824e198315787e8446",
+    "zh:56eae388c48a844401e44811719dc23be84de538468fd12b7265b06acbf4b51d",
+    "zh:614a918fdf27416b2ee2ce1737895b791f59f9deff3b61246c62a992eabfb8eb",
+    "zh:68605e159177b57fdc4a26bb2caff69a7b69593a601145b7ab5a86fd44b28b9f",
+    "zh:771ac00fd5f211052d735ff0e4b9ec67288abd1e22ffea4ed774aec73c7e5687",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a1355841161e5b53dc3078c88aae1972fd4a9c0d30309b18b1951137b96571fa",
+    "zh:a3c8ca40c1fa7ad76d3d4c3c0039b66a93cc96399e757d2caa0b5cdedce9d3e8",
+    "zh:c77e02a72ef9eb0eb65faaf84c33af843520622dbb51ec31d04ca371bd4d4ee8",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.7.2"
+  hashes = [
+    "h1:0hcNr59VEJbhZYwuDE/ysmyTS0evkfcLarlni+zATPM=",
+    "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
+    "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
+    "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",
+    "zh:24536dec8bde66753f4b4030b8f3ef43c196d69cccbea1c382d01b222478c7a3",
+    "zh:29f1786486759fad9b0ce4fdfbbfece9343ad47cd50119045075e05afe49d212",
+    "zh:4d701e978c2dd8604ba1ce962b047607701e65c078cb22e97171513e9e57491f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b8434212eef0f8c83f5a90c6d76feaf850f6502b61b53c329e85b3b281cba34",
+    "zh:ac8a23c212258b7976e1621275e3af7099e7e4a3d4478cf8d5d2a27f3bc3e967",
+    "zh:b516ca74431f3df4c6cf90ddcdb4042c626e026317a33c53f0b445a3d93b720d",
+    "zh:dc76e4326aec2490c1600d6871a95e78f9050f9ce427c71707ea412a2f2f1a62",
+    "zh:eac7b63e86c749c7d48f527671c7aee5b4e26c10be6ad7232d6860167f99dbb0",
+  ]
+}

--- a/terraform/foundation/main.tf
+++ b/terraform/foundation/main.tf
@@ -1,0 +1,50 @@
+# This configuration creates the founadtional resources for the Terraform remote state
+# It should be aplied MANUALLY ONE TIME from my local machine. So, I can access and use the created AWS resources for the rest of the project
+
+# Random suffix to ensure the S3 bucket name is globally unique (lowercase letters and numbers). Not realy neccessary for a small project like mine, but good practice
+resource "random_string" "suffix" {
+    length  = 8
+    special = false
+    upper   = false
+}
+
+# The S3 bucket that will store the terraform.tfstate file
+resource "aws_s3_bucket" "terraform_state" {
+    bucket = "${var.project_name}-tfstate-${random_string.suffix.result}"
+
+    lifecycle {
+        prevent_destroy = true
+    }
+}
+
+# Standalone resource to manage S3 bucket versioning
+resource "aws_s3_bucket_versioning" "state_bucket_versioning" {
+    bucket = aws_s3_bucket.terraform_state.id
+
+    versioning_configuration {
+        status = "Enabled"
+    }
+}
+
+# Standalone resource to manage server-side encryption
+resource "aws_s3_bucket_server_side_encryption_configuration" "state_bucket_sse" {
+    bucket = aws_s3_bucket.terraform_state.id
+
+    rule {
+        apply_server_side_encryption_by_default {
+            sse_algorithm = "AES256"
+        }
+    }
+}
+
+# The DynamoDB table for state locking to prevent concurrent runs from corrupting state
+resource "aws_dynamodb_table" "terraform_locks" {
+    name         = "${var.project_name}-terraform-locks"
+    billing_mode = "PAY_PER_REQUEST"
+    hash_key     = "LockID"
+
+    attribute {
+        name = "LockID"
+        type = "S"
+    }
+}

--- a/terraform/foundation/outputs.tf
+++ b/terraform/foundation/outputs.tf
@@ -1,0 +1,9 @@
+output "s3_bucket_name" {
+    description = "The name of the S3 bucket for Terraform state"
+    value       = aws_s3_bucket.terraform_state.bucket
+}
+
+output "dynamodb_table_name" {
+    description = "The name of the DynamoDB table for Terraform state locks"
+    value       = aws_dynamodb_table.terraform_locks.name
+}

--- a/terraform/foundation/providers.tf
+++ b/terraform/foundation/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+    region = var.aws_region
+}

--- a/terraform/foundation/variables.tf
+++ b/terraform/foundation/variables.tf
@@ -1,0 +1,11 @@
+variable "project_name" {
+    description = "The name of the project, used to prefix resource names"
+    type        = string
+    default     = "csv2json"
+}
+
+variable "aws_region" {
+    description = "The AWS region to deploy the backend resources in (London is the default region)"
+    type        = string
+    default     = "eu-west-2"
+}

--- a/terraform/foundation/versions.tf
+++ b/terraform/foundation/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+    required_version = ">= 1.13.1"
+
+    # For this initial run, I use a local backend. After these resources are created, the main pipeline will use the created S3 backend on AWS
+    backend "local" {}
+
+    required_providers {
+        aws = {
+            source  = "hashicorp/aws"
+            version = "~> 6.0"
+        }
+    }
+}


### PR DESCRIPTION
This PR establishes the foundational infrastructure for the project's Terraform remote state backend

It creates:
 - An S3 bucket to securely store the terraform.tfstate file
 - A DynamoDB table to handle state locking and prevent race conditions

These resources were provisioned manually as a one-time setup. This backend is a prerequisite for enabling the automated CI/CD pipeline in the next stage.