### PR TITLE
feat: Configure S3 remote backend for Terraform state

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,11 @@
+variable "project_name" {
+    description = "The name of the project, used to prefix resource names"
+    type        = string
+    default     = "csv2json"
+}
+
+variable "aws_region" {
+    description = "The AWS region to deploy the backend resources in (London is the default region)"
+    type        = string
+    default     = "eu-west-2"
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+    # This uses the S3 bucket and DynamoDB table I ALREADY created in the foundation stage (with /terraform/foundation/ terraform files)
+    backend "s3" {
+        bucket = "csv2json-tfstate-mz1gpchf"
+        key    = "csv2json/terraform.tfstate"
+        region = var.aws_region
+        dynamodb_table = "csv2json-terraform-locks"
+    }
+
+    required_providers {
+        aws = {
+        source  = "hashicorp/aws"
+        version = "~> 6.0"
+        }
+    }
+}


### PR DESCRIPTION
This PR configures the root Terraform project to use the S3 remote backend that was created in the foundation stage

This change is a critical prerequisite for enabling the CI/CD pipeline, as it provides a central and secure location for the Terraform state file. The backend is configred to use:
 - S3 for state file storage
 - DynamoDB for state locking to prevent race conditions