### PR TITLE
Refactor/dynamic backend

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/terraform/foundation/variables.tf
+++ b/terraform/foundation/variables.tf
@@ -7,5 +7,5 @@ variable "project_name" {
 variable "aws_region" {
     description = "The AWS region to deploy the backend resources in (London is the default region)"
     type        = string
-    default     = "eu-west-2"
+    default     = "eu-central-1"
 }

--- a/terraform/init.sh
+++ b/terraform/init.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# This script dynamically initializes the Terraform backend by fetching resource names from the 'foundation' module
+
+set -e
+
+echo "Fetching backend configuration from 'foundation' outputs..."
+
+BUCKET_NAME=$(terraform -chdir=./foundation output -raw s3_bucket_name)
+TABLE_NAME=$(terraform -chdir=./foundation output -raw dynamodb_table_name)
+
+echo "Backend S3 Bucket: $BUCKET_NAME"
+echo "Backend DynamoDB Table: $TABLE_NAME"
+
+echo "Initializing Terraform for the main project..."
+
+terraform init -reconfigure \
+    -backend-config="bucket=$BUCKET_NAME" \
+    -backend-config="key=csv2json/terraform.tfstate" \
+    -backend-config="region=eu-central-1" \
+    -backend-config="dynamodb_table=$TABLE_NAME"
+
+echo ""
+echo "Terraform initialization complete."

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,5 +7,5 @@ variable "project_name" {
 variable "aws_region" {
     description = "The AWS region to deploy the backend resources in (London is the default region)"
     type        = string
-    default     = "eu-west-2"
+    default     = "eu-central-1"
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,19 +1,4 @@
 # This uses the S3 bucket and DynamoDB table I ALREADY created in the foundation stage (with /terraform/foundation/ terraform files)
-# terraform {
-#     backend "s3" {
-#         bucket = "csv2json-tfstate-mz1gpchf"
-#         key    = "csv2json/terraform.tfstate"
-#         region ="eu-west-2"
-#         dynamodb_table = "csv2json-terraform-locks"
-#     }
-
-#     required_providers {
-#         aws = {
-#             source  = "hashicorp/aws"
-#             version = "~> 6.0"
-#         }
-#     }
-# }
 
 terraform {
     backend "s3" {

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,11 +1,23 @@
 # This uses the S3 bucket and DynamoDB table I ALREADY created in the foundation stage (with /terraform/foundation/ terraform files)
+# terraform {
+#     backend "s3" {
+#         bucket = "csv2json-tfstate-mz1gpchf"
+#         key    = "csv2json/terraform.tfstate"
+#         region ="eu-west-2"
+#         dynamodb_table = "csv2json-terraform-locks"
+#     }
+
+#     required_providers {
+#         aws = {
+#             source  = "hashicorp/aws"
+#             version = "~> 6.0"
+#         }
+#     }
+# }
 
 terraform {
     backend "s3" {
-        bucket = "csv2json-tfstate-mz1gpchf"
-        key    = "csv2json/terraform.tfstate"
-        region ="eu-west-2"
-        dynamodb_table = "csv2json-terraform-locks"
+        # Configuration will be provided via the init command
     }
 
     required_providers {


### PR DESCRIPTION
This pull request removes the hard-coded S3 bucket and DynamoDB table names from the main Terraform backend configuration.

It introduces a new init.sh script that dynamically fetches these values from the foundation module's outputs and passes them to the terraform init command.

This change automates the setup process, removing the manual copy-paste step that was previously required.