### PR TITLE
chore: Add CI/CD workflow for Terraform deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,43 @@
+name: 'Deploy Terraform Infrastructure'
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: 'Deploy to AWS'
+    runs-on: ubuntu-latest
+    
+    working-directory: ./terraform
+
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+
+      - name: 'Configure AWS Credentials'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-central-1
+
+      - name: 'Setup Terraform'
+        uses: hashicorp/setup-terraform@v3
+
+      - name: 'Terraform Init'
+        id: init
+        run: |
+          terraform init -reconfigure \
+            -backend-config="bucket=${{ secrets.TF_STATE_BUCKET }}" \
+            -backend-config="key=csv2json/terraform.tfstate" \
+            -backend-config="region=eu-central-1" \
+            -backend-config="dynamodb_table=${{ secrets.TF_STATE_LOCK_TABLE }}"
+      
+      - name: 'Terraform Apply'
+        id: apply
+        run: terraform apply -auto-approve


### PR DESCRIPTION
Closes #8

This PR adds the `.github/workflows/deploy.yml` workflow to automatically deploy the Terraform infrastructure to AWS when changes are merged into `main`.

### Key Changes:
- **Trigger:** The workflow runs on `push` to the `main` branch
- **Authentication:** Securely configures AWS credentials using the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` repository secrets
- **Backend Initialization:** Runs `terraform init` within the `/terraform` directory, passing the S3 backend bucket and DynamoDB lock table names from `TF_STATE_BUCKET` and `TF_STATE_LOCK_TABLE` secrets
- **Deployment:** Runs `terraform apply -auto-approve` to apply any changes to the infrastructure