### PR TITLE
fix(cicd): Correct 'working-directory' syntax in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,9 @@ jobs:
     name: 'Deploy to AWS'
     runs-on: ubuntu-latest
     
-    working-directory: ./terraform
+    defaults:
+      run:
+        working-directory: ./terraform
 
     steps:
       - name: 'Checkout'


### PR DESCRIPTION
This is a hotfix for the deploy workflow, which was failing with an "Invalid workflow file" error.

The error was caused by placing the `working-directory` keyword at the job level. This PR moves `working-directory: ./terraform` inside a `defaults: run:` block, which is the correct syntax.

This change unblocks the CI/CD pipeline and will allow the `terraform init` and `terraform apply` steps to run successfully.